### PR TITLE
Using rbindlist instead of rbind

### DIFF
--- a/R/scaling_up_functs.R
+++ b/R/scaling_up_functs.R
@@ -323,7 +323,7 @@ run_gRNA_gene_pair_analysis_at_scale <- function(pod_id, gene_precomp_dir, gRNA_
   # Create and save the result dataframe
   out_df <-
 
-  out_df <- do.call(what = "rbind", args = out_l) %>%
+  out_df <- rbindlist(out_l) %>%
     dplyr::mutate(gRNA_id = results_dict$gRNA_id, gene_id = results_dict$gene_id) %>%
     dplyr::relocate(gene_id, gRNA_id)
   out_fp <- (results_dict %>% dplyr::pull(result_file))[1] %>% as.character()
@@ -343,7 +343,7 @@ run_gRNA_gene_pair_analysis_at_scale <- function(pod_id, gene_precomp_dir, gRNA_
 collect_results <- function(results_dir, gene_gRNA_group_pairs) {
   file_names <- list.files(results_dir)
   to_load <- grep(pattern = 'result_[0-9]+.fst', x = file_names, value = TRUE)
-  all_results <- results_dir %>% paste0("/", to_load) %>% purrr::map(fst::read_fst) %>% purrr::reduce(rbind)
+  all_results <- results_dir %>% paste0("/", to_load) %>% purrr::map(fst::read_fst) %>% rbindlist() #purrr::reduce(rbind)
   if (ncol(gene_gRNA_group_pairs) >= 3) {
     all_results <- dplyr::left_join(gene_gRNA_group_pairs, all_results)
   }


### PR DESCRIPTION
I found that using rbindlist(...) over rbind within the `run_gRNA_gene_pair_analysis_at_scale()` func (and also `collect_results`) had performance improvements for testing large amounts of pairs in speed and memory usage.

I also found this useful/reference: https://stackoverflow.com/questions/15673550/why-is-rbindlist-better-than-rbind