### PR TITLE
Assign the same grna_id to multiple grna_targets

### DIFF
--- a/R/assign_grna_functions.R
+++ b/R/assign_grna_functions.R
@@ -142,6 +142,7 @@ process_initial_assignment_list <- function(sceptre_object) {
     curr_grna_ids <- targeting_grna_group_data_table[
       targeting_grna_group_data_table$grna_group == targeting_grna_group,
     ]$grna_id
+    curr_grna_ids <- unique(curr_grna_ids)
     initial_assignment_list[curr_grna_ids] |>
       unlist() |>
       unique()
@@ -149,7 +150,8 @@ process_initial_assignment_list <- function(sceptre_object) {
   # 4. obtain the individual non-targeting grna idxs
   nontargeting_grna_ids <- grna_target_data_frame |>
     dplyr::filter(grna_group == "non-targeting") |>
-    dplyr::pull(grna_id)
+    dplyr::pull(grna_id) |>
+    unique()
   indiv_nt_grna_idxs <- initial_assignment_list[nontargeting_grna_ids]
   # 5. construct the grna_group_idxs list
   grna_assignments_raw <- list(
@@ -182,9 +184,10 @@ determine_grnas_in_use <- function(sceptre_object, restricted_grnas = FALSE) {
         dplyr::sample_n(min(dplyr::n(), 30)) |> dplyr::pull(grna_target), "non-targeting")
     }
     grnas_in_use <- dplyr::filter(grna_target_data_frame, grna_target %in% all_grna_targets) |>
-      dplyr::pull(grna_id)
+      dplyr::pull(grna_id) |>
+      unique()
   } else {
-    grnas_in_use <- grna_target_data_frame$grna_id
+    grnas_in_use <- unique(grna_target_data_frame$grna_id)
   }
   return(grnas_in_use)
 }

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -205,6 +205,23 @@ check_set_analysis_parameters <- function(sceptre_object, formula_object, respon
     stop("`grna_integration_strategy` must be either 'union', 'singleton', or 'bonferroni'.")
   }
 
+  # 9.5. warn about multi-target gRNAs in union mode
+  if (grna_integration_strategy == "union") {
+    multi_target_grna_ids <- grna_target_data_frame |>
+      dplyr::group_by(grna_id) |>
+      dplyr::summarize(n_targets = dplyr::n_distinct(grna_target), .groups = "drop") |>
+      dplyr::filter(n_targets > 1L)
+    if (nrow(multi_target_grna_ids) >= 1L) {
+      example_ids <- head(as.character(multi_target_grna_ids$grna_id), 5L)
+      warning(
+        "In `union` mode, some `grna_id`s map to multiple `grna_target`s. ",
+        "These guides will contribute treated cells to multiple target groups (overlapping treated sets), ",
+        "which can induce correlation across tests. ",
+        "Example `grna_id`s: ", paste0(example_ids, collapse = ", ")
+      )
+    }
+  }
+
   # 10. if using a backing .odm file, verify that resampling mechanism is permutations
   if (methods::is(get_response_matrix(sceptre_object), "odm") && (resampling_mechanism != "permutations")) {
     stop("`resampling_mechanism` must be set to 'permutations' when using an ondisc-backed sceptre_object.")

--- a/R/neg_control_functions.R
+++ b/R/neg_control_functions.R
@@ -106,13 +106,15 @@ construct_negative_control_pairs_v2 <- function(sceptre_object, n_calibration_pa
 compute_calibration_group_size <- function(grna_target_data_frame) {
   median_group_size <- grna_target_data_frame |>
     dplyr::filter(grna_group != "non-targeting") |>
-    dplyr::pull(grna_group) |>
-    table() |>
+    dplyr::group_by(grna_group) |>
+    dplyr::summarize(n_guides = dplyr::n_distinct(grna_id), .groups = "drop") |>
+    dplyr::pull(n_guides) |>
     stats::median() |>
     round()
   n_ntc <- grna_target_data_frame |>
     dplyr::filter(grna_group == "non-targeting") |>
-    nrow()
+    dplyr::summarize(n_guides = dplyr::n_distinct(grna_id)) |>
+    dplyr::pull(n_guides)
   calibration_group_size <- as.integer(min(median_group_size, n_ntc))
   return(calibration_group_size)
 }

--- a/R/pairwise_qc_functs.R
+++ b/R/pairwise_qc_functs.R
@@ -107,10 +107,11 @@ compute_qc_metrics <- function(sceptre_object) {
         dplyr::mutate(pass_qc = (n_nonzero_trt >= n_nonzero_trt_thresh & n_nonzero_cntrl >= n_nonzero_cntrl_thresh))
       if (sceptre_object@grna_integration_strategy == "bonferroni") {
         grna_target_data_frame <- sceptre_object@grna_target_data_frame |>
-          dplyr::select(grna_id, grna_target)
+          dplyr::select(grna_id, grna_target) |>
+          dplyr::distinct()
         n_ok_pairs <- methods::slot(sceptre_object, data_frame_name) |>
           dplyr::select("grna_id" = "grna_group", pass_qc, response_id) |>
-          dplyr::left_join(grna_target_data_frame, by = "grna_id") |>
+          dplyr::left_join(grna_target_data_frame, by = "grna_id", relationship = "many-to-many") |>
           dplyr::group_by(response_id, grna_target) |>
           dplyr::summarize(any_pass_qc = any(pass_qc), .groups = "drop") |>
           dplyr::pull(any_pass_qc) |>

--- a/R/s4_analysis_functs_2.R
+++ b/R/s4_analysis_functs_2.R
@@ -360,10 +360,11 @@ apply_grouping_to_result <- function(result, sceptre_object, is_calibration_chec
   }
   if (grna_integration_strategy %in% c("singleton", "bonferroni")) {
     grna_target_data_frame <- sceptre_object@grna_target_data_frame |>
-      dplyr::select(grna_id, grna_target)
+      dplyr::select(grna_id, grna_target) |>
+      dplyr::distinct()
     new_result <- result |>
       dplyr::rename("grna_id" = "grna_group") |>
-      dplyr::left_join(grna_target_data_frame, by = "grna_id") |>
+      dplyr::left_join(grna_target_data_frame, by = "grna_id", relationship = "many-to-many") |>
       dplyr::relocate(response_id, grna_id, grna_target)
     if (grna_integration_strategy == "bonferroni" && !is_calibration_check) {
       new_result <- new_result |>


### PR DESCRIPTION
Hi,
We have recently been analyzing datasets where we want to assign a single guide to multiple target groups.  The `grna_target_data_frame` will look like this:

**guide_1** target_1
guide_2 target_1
**guide_1** target_2
guide_3 target_2

I think there were two points of concern:
- **“sceptre would repeat gRNA assignment for each gRNA/target pair”**  
    Now, the list of guides that get assigned is deduplicated via `unique(grna_id)` in `determine_grnas_in_use()` in [[assign_grna_functions.R:172]
So duplicating rows in `grna_target_data_frame` does _not_ cause repeated per-guide assignment work.
    
- **“sceptre’s calculation of MOI would be off”**  
    The MOI shown in `plot_assign_grnas()` is computed as `mean(sceptre_object@grnas_per_cell)` in [[plotting_functions.R:250]
    `grnas_per_cell` comes from the actual assignment list (how many distinct guides were assigned per cell), not from counting rows in `grna_target_data_frame`. Since we now avoid duplicated guide IDs during assignment, duplicating mapping rows does **not** inflate `grnas_per_cell`, so MOI won’t be biased by the mapping duplication.

I believe the changes above will address these problems in both high and low MOI modes.

The code passes the unit tests that you wrote.

