### PR TITLE
[codex] Use parallelly fraction for auto processors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     scales,
     stats,
     purrr,
-    parallelly
+    parallelly (>= 1.47.0)
 Depends: 
     R (>= 4.1)
 Suggests:

--- a/R/aux_functions.R
+++ b/R/aux_functions.R
@@ -85,7 +85,7 @@ auto_compute_cell_covariates <- function(response_matrix, grna_matrix, extra_cov
 partition_response_ids <- function(response_ids, parallel, n_processors) {
   groups_set <- FALSE
   if (parallel) {
-    if (identical(n_processors, "auto")) n_processors <- max(1L, floor(parallelly::availableCores(logical = FALSE)/2))
+    if (identical(n_processors, "auto")) n_processors <- parallelly::availableCores(fraction = 0.5, logical = FALSE)
     if (length(response_ids) >= 2 * n_processors) {
       set.seed(4)
       s <- sample(response_ids)


### PR DESCRIPTION
## Summary
- Replace the manual half-core calculation for `n_processors = "auto"` with `parallelly::availableCores(fraction = 0.5, logical = FALSE)` as suggested in https://github.com/Katsevich-Lab/sceptre/issues/128#issuecomment-4360414961.
- Require `parallelly >= 1.47.0`, where the `fraction` argument is available.

## Validation
- `Rscript -e "devtools::test(filter = 'aux_functions')"`
- `R CMD build --no-build-vignettes /Users/ekatsevi/.codex/worktrees/1c89/sceptre`
- `R CMD check --no-manual --no-build-vignettes sceptre_0.10.3.tar.gz` (2 vignette warnings and 1 hidden `.git` note, all unrelated to this change)