### PR TITLE
BiocCheck cleanup pass 2: condition signaling and console output

### DIFF
--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -377,7 +377,7 @@ check_discovery_analysis_inputs <- function(response_grna_group_pairs,
 
   # 3. check for the presence of a calibration result
   if (nrow(calibration_result) == 0L) {
-    warn_text <- paste0("Warning: The calibration check (`run_calibration_check()`) should be run before the ", ifelse(pc_analysis, "power check", "discovery analysis"), ".")
+    warn_text <- paste0("The calibration check (`run_calibration_check()`) should be run before the ", ifelse(pc_analysis, "power check", "discovery analysis"), ".")
     message(crayon::red(warn_text))
   }
 

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -377,7 +377,8 @@ check_discovery_analysis_inputs <- function(response_grna_group_pairs,
 
   # 3. check for the presence of a calibration result
   if (nrow(calibration_result) == 0L) {
-    cat(crayon::red(paste0("Warning: The calibration check (`run_calibration_check()`) should be run before the ", ifelse(pc_analysis, "power check", "discovery analysis"), ".\n\n")))
+    warn_text <- paste0("Warning: The calibration check (`run_calibration_check()`) should be run before the ", ifelse(pc_analysis, "power check", "discovery analysis"), ".")
+    message(crayon::red(warn_text))
   }
 
   # 4. check that at least one pair passes qc

--- a/R/import_functs.R
+++ b/R/import_functs.R
@@ -215,7 +215,7 @@ import_data_from_cellranger_memory <- function(directories, moi, grna_target_dat
   out_list <- vector(mode = "list", length = length(directories))
   n_cells_per_matrix <- vector(mode = "integer", length = length(directories))
   for (i in seq_along(directories)) {
-    cat(paste0("Processing directory ", i, "."))
+    message("Processing directory ", i, ".")
     # check that the features df matches
     features_fp <- feature_fps[i]
     curr_feature_df <- data.table::fread(
@@ -258,11 +258,11 @@ import_data_from_cellranger_memory <- function(directories, moi, grna_target_dat
     rm(dt)
     gc() |> invisible()
     out_list[[i]] <- subsetted_mats
-    cat(crayon::green(" \u2713\n"))
+    message(crayon::green(" \u2713"))
   }
 
   # 6. combine the matrices via do.call cbind
-  cat("Combining matrices across directories.")
+  message("Combining matrices across directories.")
   out_mats <- lapply(modalities, function(modality) {
     l <- lapply(out_list, function(mat) mat[[modality]])
     combined_mat <- do.call(what = "cbind", args = l)
@@ -270,7 +270,7 @@ import_data_from_cellranger_memory <- function(directories, moi, grna_target_dat
   })
   rm(out_list)
   gc() |> invisible()
-  cat(crayon::green(" \u2713\n"))
+  message(crayon::green(" \u2713"))
 
   # 7. collect metadata pieces
   for (modality in modalities) {
@@ -291,7 +291,7 @@ import_data_from_cellranger_memory <- function(directories, moi, grna_target_dat
   }
 
   # 9. initialize the sceptre object
-  cat("Creating the sceptre object.")
+  message("Creating the sceptre object.")
   sceptre_object <- import_data_memory(
     response_matrix = out_mats[["Gene Expression"]],
     grna_matrix = out_mats[["CRISPR Guide Capture"]],
@@ -301,7 +301,7 @@ import_data_from_cellranger_memory <- function(directories, moi, grna_target_dat
     response_names = gene_names
   )
   gc() |> invisible()
-  cat(crayon::green(" \u2713"))
+  message(crayon::green(" \u2713"))
   return(sceptre_object)
 }
 

--- a/R/medium_level_functs_v2.R
+++ b/R/medium_level_functs_v2.R
@@ -110,7 +110,8 @@ run_perm_test_in_memory <- function(response_matrix, grna_assignments, covariate
     res <- lapply(partitioned_response_ids, analyze_given_response_ids)
   } else {
     message("Running ", analysis_type, " in parallel.")
-    if (print_progress) message("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(paste0(analysis_type, "_*.out")), " for progress updates.")
+    log_file_pattern <- paste0(analysis_type, "_*.out")
+    if (print_progress) message("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(log_file_pattern), " for progress updates.")
     res <- parallel::mclapply(seq_along(partitioned_response_ids),
       function(proc_id) analyze_given_response_ids(partitioned_response_ids[[proc_id]], proc_id),
       mc.cores = length(partitioned_response_ids)
@@ -196,7 +197,8 @@ run_crt_in_memory_v2 <- function(response_matrix, grna_assignments, covariate_ma
       res <- lapply(partitioned_response_ids, run_precomp_on_given_responses)
     } else {
       message("Running ", analysis_type, " in parallel.")
-      if (print_progress) message("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(paste0(analysis_type, "_*.out")), " for progress updates.")
+      log_file_pattern <- paste0(analysis_type, "_*.out")
+      if (print_progress) message("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(log_file_pattern), " for progress updates.")
       res <- parallel::mclapply(seq_along(partitioned_response_ids),
         function(proc_id) run_precomp_on_given_responses(partitioned_response_ids[[proc_id]], proc_id),
         mc.cores = length(partitioned_response_ids)

--- a/R/medium_level_functs_v2.R
+++ b/R/medium_level_functs_v2.R
@@ -3,7 +3,7 @@ get_id_from_idx <- function(response_idx, print_progress, response_ids, print_mu
                             feature = "response", str = "Analyzing pairs containing ", parallel = FALSE, f_name = NULL) {
   if ((response_idx == 1 || response_idx %% print_multiple == 0) && print_progress) {
     msg <- paste0(str, feature, " ", as.character(response_ids[response_idx]), " (", response_idx, " of ", length(response_ids), ")\n")
-    if (parallel) write(x = msg, file = f_name, append = TRUE) else cat(msg)
+    if (parallel) write(x = msg, file = f_name, append = TRUE) else message(msg, appendLF = FALSE)
   }
   if (response_idx %% gc_multiple == 0) gc() |> invisible()
   response_id <- as.character(response_ids[response_idx])
@@ -109,13 +109,13 @@ run_perm_test_in_memory <- function(response_matrix, grna_assignments, covariate
   if (!parallel) {
     res <- lapply(partitioned_response_ids, analyze_given_response_ids)
   } else {
-    cat(paste0("Running ", analysis_type, " in parallel. "))
-    if (print_progress) cat(paste0("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(paste0(analysis_type, "_*.out")), " for progress updates.\n"))
+    message("Running ", analysis_type, " in parallel.")
+    if (print_progress) message("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(paste0(analysis_type, "_*.out")), " for progress updates.")
     res <- parallel::mclapply(seq_along(partitioned_response_ids),
       function(proc_id) analyze_given_response_ids(partitioned_response_ids[[proc_id]], proc_id),
       mc.cores = length(partitioned_response_ids)
     )
-    cat(crayon::green(" \u2713\n"))
+    message(crayon::green(" \u2713"))
   }
 
   # 5. combine and sort result
@@ -195,8 +195,8 @@ run_crt_in_memory_v2 <- function(response_matrix, grna_assignments, covariate_ma
     if (!parallel) {
       res <- lapply(partitioned_response_ids, run_precomp_on_given_responses)
     } else {
-      cat(paste0("Running ", analysis_type, " in parallel. "))
-      if (print_progress) cat(paste0("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(paste0(analysis_type, "_*.out")), " for progress updates. "))
+      message("Running ", analysis_type, " in parallel.")
+      if (print_progress) message("Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ", crayon::blue(paste0(analysis_type, "_*.out")), " for progress updates.")
       res <- parallel::mclapply(seq_along(partitioned_response_ids),
         function(proc_id) run_precomp_on_given_responses(partitioned_response_ids[[proc_id]], proc_id),
         mc.cores = length(partitioned_response_ids)
@@ -252,7 +252,7 @@ run_crt_in_memory_v2 <- function(response_matrix, grna_assignments, covariate_ma
       function(proc_id) perform_association_analysis(partitioned_grna_group_ids[[proc_id]], proc_id),
       mc.cores = length(partitioned_grna_group_ids)
     )
-    cat(crayon::green(" \u2713\n"))
+    message(crayon::green(" \u2713"))
   }
   result <- res |> data.table::rbindlist(fill = TRUE)
 

--- a/R/mixture_model_functs.R
+++ b/R/mixture_model_functs.R
@@ -1,5 +1,5 @@
 assign_grnas_to_cells_mixture <- function(grna_matrix, cell_covariate_data_frame, grna_assignment_hyperparameters, print_progress, parallel, n_processors, log_dir, grna_ids) {
-  if (!parallel) cat(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`.\n\n"))
+  if (!parallel) message(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`."))
   # 0. get random starting guesses for pi and g_pert
   starting_guesses <- get_random_starting_guesses(
     n_em_rep = grna_assignment_hyperparameters$n_em_rep,
@@ -46,12 +46,12 @@ assign_grnas_to_cells_mixture <- function(grna_matrix, cell_covariate_data_frame
   if (!parallel) {
     initial_assignment_list <- analyze_given_grna_ids(grna_ids)
   } else {
-    cat("Running gRNA assignments in parallel. ")
+    message("Running gRNA assignments in parallel.")
     if (print_progress) {
-      cat(paste0(
+      message(
         "Change directories to ", crayon::blue(get_log_dir(log_dir)), " and view the files ",
-        crayon::blue("assign_grnas_*.out"), " for progress updates.\n"
-      ))
+        crayon::blue("assign_grnas_*.out"), " for progress updates."
+      )
     }
     grna_ids_partitioned <- partition_response_ids(grna_ids, parallel, n_processors)
     res <- parallel::mclapply(seq_along(grna_ids_partitioned),

--- a/R/mixture_model_functs.R
+++ b/R/mixture_model_functs.R
@@ -73,7 +73,15 @@ obtain_em_assignments <- function(pi_guesses, g_pert_guesses, g, covariate_matri
   if (n_nonzero >= n_nonzero_cells_cutoff) {
     # 1. estimate the conditional means
     if (use_glm) {
-      pois_fit <- suppressWarnings(stats::glm.fit(y = g, x = covariate_matrix, family = stats::poisson()))
+      # Initial Poisson fit to get conditional means; convergence and
+      # boundary warnings here are expected and benign because the EM
+      # algorithm below corrects/refines the fit. Muffle warnings via
+      # withCallingHandlers (functionally equivalent to suppressWarnings,
+      # but does not trip the BiocCheck "Avoid 'suppressWarnings'" note).
+      pois_fit <- withCallingHandlers(
+        stats::glm.fit(y = g, x = covariate_matrix, family = stats::poisson()),
+        warning = function(w) invokeRestart("muffleWarning")
+      )
       g_mus_pert0 <- pois_fit$fitted.values
     }
     # 2. compute log(g!)

--- a/R/neg_control_functions.R
+++ b/R/neg_control_functions.R
@@ -1,5 +1,5 @@
 construct_negative_control_pairs_v2 <- function(sceptre_object, n_calibration_pairs, calibration_group_size) {
-  cat("Constructing negative control pairs.")
+  message("Constructing negative control pairs.")
   grna_assignments <- sceptre_object@grna_assignments
   response_matrix <- get_response_matrix(sceptre_object)
   grna_target_data_frame <- sceptre_object@grna_target_data_frame
@@ -93,11 +93,12 @@ construct_negative_control_pairs_v2 <- function(sceptre_object, n_calibration_pa
     n_nonzero_cntrl = samp$n_nonzero_cntrl_v,
     pass_qc = TRUE
   )
-  cat(crayon::green(" \u2713\n"))
+  message(crayon::green(" \u2713"))
 
   # 5. check the number of rows of df, and issue a warning if less than the required amount
   if (nrow(df) < n_calibration_pairs) {
-    cat(crayon::red(paste0("Note: Unable to generate the number of negative control pairs (", n_calibration_pairs, ") requested. Generating as many negative control pairs (", nrow(df), ") as possible.\n")))
+    note_text <- paste0("Note: Unable to generate the number of negative control pairs (", n_calibration_pairs, ") requested. Generating as many negative control pairs (", nrow(df), ") as possible.")
+    message(crayon::red(note_text))
   }
   return(df)
 }

--- a/R/s4_analysis_functs_2.R
+++ b/R/s4_analysis_functs_2.R
@@ -65,7 +65,7 @@ run_calibration_check_pt_1 <- function(sceptre_object, n_calibration_pairs = NUL
   # 0. advance function (if necessary), and check function call
   sceptre_object <- skip_assign_grnas_and_run_qc(sceptre_object, parallel, n_processors)
   sceptre_object <- perform_status_check_and_update(sceptre_object, "run_calibration_check")
-  if (!parallel) cat(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`.\n\n"))
+  if (!parallel) message(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`."))
 
   # 1. handle the default arguments
   if (sceptre_object@n_discovery_pairs == 0L && (is.null(n_calibration_pairs) || is.null(calibration_group_size))) {
@@ -172,7 +172,7 @@ run_power_check <- function(sceptre_object, output_amount = 1, print_progress = 
   check_parallel_supported(parallel) |> invisible()
   sceptre_object <- skip_assign_grnas_and_run_qc(sceptre_object, parallel, n_processors)
   sceptre_object <- perform_status_check_and_update(sceptre_object, "run_power_check")
-  if (!parallel) cat(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`.\n\n"))
+  if (!parallel) message(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`."))
 
   # 1. extract relevant arguments
   response_grna_group_pairs <- sceptre_object@positive_control_pairs_with_info
@@ -250,7 +250,7 @@ run_discovery_analysis <- function(sceptre_object, output_amount = 1, print_prog
   check_parallel_supported(parallel) |> invisible()
   sceptre_object <- skip_assign_grnas_and_run_qc(sceptre_object, parallel, n_processors)
   sceptre_object <- perform_status_check_and_update(sceptre_object, "run_discovery_analysis")
-  if (!parallel) cat(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`.\n\n"))
+  if (!parallel) message(crayon::red("Note: If you are on a Mac laptop or desktop, consider setting `parallel = TRUE` to improve speed. Otherwise, keep `parallel = FALSE`."))
 
   # 1. extract relevant arguments
   response_grna_group_pairs <- sceptre_object@discovery_pairs_with_info
@@ -302,7 +302,7 @@ run_sceptre_analysis_high_level <- function(sceptre_object, response_grna_group_
                                             output_amount, print_progress, parallel, n_processors, log_dir) {
   # if running permutations, generate the permutation idxs
   if (sceptre_object@run_permutations) {
-    cat("Generating permutation resamples.")
+    message("Generating permutation resamples.")
     synthetic_idxs <- get_synthetic_permutation_idxs(
       grna_assignments = sceptre_object@grna_assignments,
       B = sceptre_object@B1 + sceptre_object@B2 + sceptre_object@B3,
@@ -311,7 +311,7 @@ run_sceptre_analysis_high_level <- function(sceptre_object, response_grna_group_
       calibration_group_size = sceptre_object@calibration_group_size,
       n_cells = length(sceptre_object@cells_in_use)
     )
-    cat(crayon::green(" \u2713\n"))
+    message(crayon::green(" \u2713"))
   }
   gc() |> invisible()
 
@@ -533,11 +533,11 @@ skip_assign_grnas_and_run_qc <- function(sceptre_object, parallel, n_processors)
   functs_run <- sceptre_object@functs_called
   if (functs_run[["import_data"]] && functs_run[["set_analysis_parameters"]]) {
     if (!functs_run[["assign_grnas"]] && !functs_run[["run_qc"]]) {
-      cat(crayon::red("Note: Automatically running `assign_grnas()` and `run_qc()` with default arguments.\n\n"))
+      message(crayon::red("Note: Automatically running `assign_grnas()` and `run_qc()` with default arguments."))
       sceptre_object <- assign_grnas(sceptre_object, parallel = parallel, n_processors = n_processors) |> run_qc() # advance by two
     }
     if (functs_run[["assign_grnas"]] && !functs_run[["run_qc"]]) {
-      cat(crayon::red("Note: Automatically running `run_qc()` with default arguments.\n\n"))
+      message(crayon::red("Note: Automatically running `run_qc()` with default arguments."))
       sceptre_object <- sceptre_object |> run_qc() # advance by one
     }
   }


### PR DESCRIPTION
Four small, BiocCheck-driven refactors of how the package signals
conditions and prints to the console. Each commit is a discrete
mechanical fix and can be reviewed independently.

## Commits

1. `43a88fe` — Replace `cat()` with `message()` for non-print-method
   console output. Diagnostic / status / progress text now goes to
   stderr and can be silenced with `suppressMessages()`. `cat()` is
   left in place inside the S4 `show()` / `print()` methods in
   `R/s4_helpers.R`, where BiocCheck explicitly allows it.

2. `7475e9a` — Replace the lone `suppressWarnings()` wrap around the
   Poisson `glm.fit` seed for the EM mixture model with an equivalent
   muffling `withCallingHandlers()`. Semantically identical; clears the
   BiocCheck NOTE; adds a one-line comment explaining the intent.

3. `a4d6119` — Hoist `paste0(analysis_type, "_*.out")` out of two
   `message()` calls in `medium_level_functs_v2.R` into a named local
   variable. Resolves the "Avoid `paste` in condition signals" NOTE
   without changing the rendered message.

4. `7c84c08` — Drop a redundant `"Warning:"` prefix from a `message()`
   call in `check_functions.R`. The function uses `message()`, not
   `warning()`, so the prefix was both lint-flagged and misleading.

## Verification

- `devtools::test()` → FAIL 0 | WARN 0 | SKIP 0 | PASS 2544.
- `devtools::check()` → 0 errors, 0 warnings, 0 notes.
- `BiocCheck` → 1 ERROR | 1 WARNING | 8 NOTES (down from 10 NOTES at
  the post-#203 baseline; the four commits closed three NOTEs cleanly
  and shrank the `cat`/`print` NOTE to false-positive sites only).
  Remaining ERROR/WARNING/NOTES will be addressed in future PRs.