### PR TITLE
Add funder roles to Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,12 @@ Authors@R:
            person(given = "Eugene",
            family = "Katsevich",
            role = c("aut"),
-           email = "ekatsevi@wharton.upenn.edu")
+           email = "ekatsevi@wharton.upenn.edu"),
+           person(given = "Wharton Analytics",
+           role = "fnd"),
+           person(given = "National Science Foundation",
+           role = "fnd",
+           comment = "Grants DMS-2113072 and DMS-2310654")
            )
 Description: Analysis of single-cell CRISPR screen data. `sceptre` is an R package for statistically rigorous, massively scalable, and user-friendly single-cell CRISPR screen data analysis. The `sceptre` pipeline consists of several distinct steps: (1) import data from 10X CellRanger, Parse CRISPR Detect, or a set of R objects; (2) set the analysis parameters, which are the parameters that govern how the statistical analysis is to be conducted; (3) assign gRNAs to cells using one of three principled methods; (4) run quality control; (5) run the calibration check, which is an analysis that verifies that `sceptre` controls the rate of false positives on the dataset under analysis; (6) run the power check, which is an analysis that verifies that `sceptre` is capable of discovering true associations on the dataset under analysis; (7) run the discovery analysis to identify high-confidence perturbation-gene links among the set of perturbations and genes whose association status we do not know but seek to learn; (8) write outputs to a specified directory, including results, plots, and a textual summary of the analysis. `sceptre` leverages several novel statistical and computational algorithms to achieve high statistical accuracy and computational speed.
 License: GPL-3


### PR DESCRIPTION
Closes the BiocCheck NOTE "No 'fnd' role found in Authors@R".

Adds two `person(role = "fnd")` entries to `Authors@R`:

- **Wharton Analytics** (supports Eugene Katsevich).
- **U.S. National Science Foundation** — Grants DMS-2113072 and DMS-2310654 (both support Eugene Katsevich).

### Verification

- `Authors@R` re-parses cleanly via `eval(parse(text = ...))`; two `fnd` entries detected.
- `devtools::check`: 0 errors / 0 warnings / 1 NOTE — the NOTE is the pre-existing `.git` worktree artifact addressed separately in [#205](https://github.com/Katsevich-Lab/sceptre/pull/205) (`.Rbuildignore` line), unrelated to this change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>