### PR TITLE
Make package example runnable and write to tempdir() instead of home

### DIFF
--- a/R/s4_analysis_functs_2.R
+++ b/R/s4_analysis_functs_2.R
@@ -452,7 +452,7 @@ get_result <- function(sceptre_object, analysis) {
 #' @param sceptre_object a `sceptre_object`
 #' @param directory a string giving the file path to a directory on disk in which to write the results
 #'
-#' @return the value NULL
+#' @return `NULL`, invisibly
 #' @export
 #' @examples
 #' data(highmoi_example_data)
@@ -525,7 +525,7 @@ write_outputs_to_directory <- function(sceptre_object, directory) {
   # 4. save gRNA-to-cell assignments
   grna_assignments <- get_grna_assignments(sceptre_object)
   saveRDS(object = grna_assignments, file = paste0(directory, "/grna_assignment_matrix.rds"))
-  return(NULL)
+  return(invisible(NULL))
 }
 
 

--- a/R/s4_analysis_functs_2.R
+++ b/R/s4_analysis_functs_2.R
@@ -660,7 +660,7 @@ get_result <- function(sceptre_object, analysis) {
 #' @param directory a string giving the file path to a directory on disk in
 #' which to write the results
 #'
-#' @return `NULL`, invisibly
+#' @return No return value; called for its side effect of writing files to `directory`.
 #' @export
 #' @examples
 #' data(highmoi_example_data)

--- a/R/s4_analysis_functs_2.R
+++ b/R/s4_analysis_functs_2.R
@@ -660,7 +660,7 @@ get_result <- function(sceptre_object, analysis) {
 #' @param directory a string giving the file path to a directory on disk in
 #' which to write the results
 #'
-#' @return the value NULL
+#' @return `NULL`, invisibly
 #' @export
 #' @examples
 #' data(highmoi_example_data)
@@ -783,7 +783,7 @@ write_outputs_to_directory <- function(sceptre_object, directory) {
         object = grna_assignments,
         file = paste0(directory, "/grna_assignment_matrix.rds")
     )
-    return(NULL)
+    return(invisible(NULL))
 }
 
 

--- a/R/s4_analysis_functs_2.R
+++ b/R/s4_analysis_functs_2.R
@@ -452,7 +452,7 @@ get_result <- function(sceptre_object, analysis) {
 #' @param sceptre_object a `sceptre_object`
 #' @param directory a string giving the file path to a directory on disk in which to write the results
 #'
-#' @return `NULL`, invisibly
+#' @return No return value; called for its side effect of writing files to `directory`.
 #' @export
 #' @examples
 #' data(highmoi_example_data)

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -72,13 +72,16 @@ utils::globalVariables(c(
 #' plot(sceptre_object)
 #' print(sceptre_object)
 #'
-#' # 8. write results
+#' # 8. write results to a directory. tempdir() is used so this example is
+#' # self-contained; for a real analysis choose a directory you can find again,
+#' # e.g. file.path("~", "sceptre_outputs").
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
 #' message("sceptre outputs written to ", output_dir)
+#' # to open this directory in your file browser: browseURL(output_dir)
 #'
 #' ##########################
 #' # High-MOI CRISPRi example
@@ -138,11 +141,14 @@ utils::globalVariables(c(
 #' plot(sceptre_object)
 #' print(sceptre_object)
 #'
-#' # 8. write results
+#' # 8. write results to a directory. tempdir() is used so this example is
+#' # self-contained; for a real analysis choose a directory you can find again,
+#' # e.g. file.path("~", "sceptre_outputs").
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
 #' message("sceptre outputs written to ", output_dir)
+#' # to open this directory in your file browser: browseURL(output_dir)
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -73,15 +73,16 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results to a directory. tempdir() is used so this example is
-#' # self-contained; for a real analysis choose a directory you can find again,
-#' # e.g. file.path("~", "sceptre_outputs").
+#' # self-contained; for a real analysis choose a directory you can find again.
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
-#' message("sceptre outputs written to ", output_dir)
-#' # to open this directory in your file browser: browseURL(output_dir)
+#' message(
+#'   "sceptre outputs written to a temporary directory; ",
+#'   'open with browseURL("', output_dir, '")'
+#' )
 #'
 #' ##########################
 #' # High-MOI CRISPRi example
@@ -142,13 +143,14 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results to a directory. tempdir() is used so this example is
-#' # self-contained; for a real analysis choose a directory you can find again,
-#' # e.g. file.path("~", "sceptre_outputs").
+#' # self-contained; for a real analysis choose a directory you can find again.
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
-#' message("sceptre outputs written to ", output_dir)
-#' # to open this directory in your file browser: browseURL(output_dir)
+#' message(
+#'   "sceptre outputs written to a temporary directory; ",
+#'   'open with browseURL("', output_dir, '")'
+#' )
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -81,7 +81,7 @@ utils::globalVariables(c(
 #' )
 #' message(
 #'   "sceptre outputs written to a temporary directory; ",
-#'   'open with browseURL("', output_dir, '")'
+#'   'open with `browseURL("', output_dir, '")`'
 #' )
 #'
 #' ##########################
@@ -151,6 +151,6 @@ utils::globalVariables(c(
 #' )
 #' message(
 #'   "sceptre outputs written to a temporary directory; ",
-#'   'open with browseURL("', output_dir, '")'
+#'   'open by running `browseURL("', output_dir, '")` in the console.'
 #' )
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -100,15 +100,16 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results to a directory. tempdir() is used so this example is
-#' # self-contained; for a real analysis choose a directory you can find again,
-#' # e.g. file.path("~", "sceptre_outputs").
+#' # self-contained; for a real analysis choose a directory you can find again.
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
-#' message("sceptre outputs written to ", output_dir)
-#' # to open this directory in your file browser: browseURL(output_dir)
+#' message(
+#'   "sceptre outputs written to a temporary directory; ",
+#'   'open with browseURL("', output_dir, '")'
+#' )
 #'
 #' ##########################
 #' # High-MOI CRISPRi example
@@ -169,13 +170,14 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results to a directory. tempdir() is used so this example is
-#' # self-contained; for a real analysis choose a directory you can find again,
-#' # e.g. file.path("~", "sceptre_outputs").
+#' # self-contained; for a real analysis choose a directory you can find again.
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
-#' message("sceptre outputs written to ", output_dir)
-#' # to open this directory in your file browser: browseURL(output_dir)
+#' message(
+#'   "sceptre outputs written to a temporary directory; ",
+#'   'open with browseURL("', output_dir, '")'
+#' )
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -42,7 +42,6 @@ utils::globalVariables(c(
 #' @importFrom Rcpp sourceCpp
 #' @keywords package
 #' @examples
-#' \donttest{
 #' ##########################
 #' # Low-MOI CRISPRko example
 #' ##########################
@@ -101,7 +100,12 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results
-#' write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_lowmoi/")
+#' output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
+#' write_outputs_to_directory(
+#'   sceptre_object = sceptre_object,
+#'   directory = output_dir
+#' )
+#' message("sceptre outputs written to ", output_dir)
 #'
 #' ##########################
 #' # High-MOI CRISPRi example
@@ -162,6 +166,10 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results
-#' write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_highmoi/")
-#' }
+#' output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
+#' write_outputs_to_directory(
+#'   sceptre_object = sceptre_object,
+#'   directory = output_dir
+#' )
+#' message("sceptre outputs written to ", output_dir)
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -15,7 +15,6 @@ utils::globalVariables(c(
 #' @importFrom Rcpp sourceCpp
 #' @keywords package
 #' @examples
-#' \donttest{
 #' ##########################
 #' # Low-MOI CRISPRko example
 #' ##########################
@@ -74,7 +73,12 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results
-#' write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_lowmoi/")
+#' output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
+#' write_outputs_to_directory(
+#'   sceptre_object = sceptre_object,
+#'   directory = output_dir
+#' )
+#' message("sceptre outputs written to ", output_dir)
 #'
 #' ##########################
 #' # High-MOI CRISPRi example
@@ -135,6 +139,10 @@ utils::globalVariables(c(
 #' print(sceptre_object)
 #'
 #' # 8. write results
-#' write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_highmoi/")
-#' }
+#' output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
+#' write_outputs_to_directory(
+#'   sceptre_object = sceptre_object,
+#'   directory = output_dir
+#' )
+#' message("sceptre outputs written to ", output_dir)
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -99,13 +99,16 @@ utils::globalVariables(c(
 #' plot(sceptre_object)
 #' print(sceptre_object)
 #'
-#' # 8. write results
+#' # 8. write results to a directory. tempdir() is used so this example is
+#' # self-contained; for a real analysis choose a directory you can find again,
+#' # e.g. file.path("~", "sceptre_outputs").
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
 #' message("sceptre outputs written to ", output_dir)
+#' # to open this directory in your file browser: browseURL(output_dir)
 #'
 #' ##########################
 #' # High-MOI CRISPRi example
@@ -165,11 +168,14 @@ utils::globalVariables(c(
 #' plot(sceptre_object)
 #' print(sceptre_object)
 #'
-#' # 8. write results
+#' # 8. write results to a directory. tempdir() is used so this example is
+#' # self-contained; for a real analysis choose a directory you can find again,
+#' # e.g. file.path("~", "sceptre_outputs").
 #' output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 #' write_outputs_to_directory(
 #'   sceptre_object = sceptre_object,
 #'   directory = output_dir
 #' )
 #' message("sceptre outputs written to ", output_dir)
+#' # to open this directory in your file browser: browseURL(output_dir)
 "_PACKAGE"

--- a/R/sceptre.R
+++ b/R/sceptre.R
@@ -108,7 +108,7 @@ utils::globalVariables(c(
 #' )
 #' message(
 #'   "sceptre outputs written to a temporary directory; ",
-#'   'open with browseURL("', output_dir, '")'
+#'   'open with `browseURL("', output_dir, '")`'
 #' )
 #'
 #' ##########################
@@ -178,6 +178,6 @@ utils::globalVariables(c(
 #' )
 #' message(
 #'   "sceptre outputs written to a temporary directory; ",
-#'   'open with browseURL("', output_dir, '")'
+#'   'open by running `browseURL("', output_dir, '")` in the console.'
 #' )
 "_PACKAGE"

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -10,7 +10,6 @@
 emphasizing statistical rigor, massive scalability, and ease of use.
 }
 \examples{
-\donttest{
 ##########################
 # Low-MOI CRISPRko example
 ##########################
@@ -69,7 +68,12 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results
-write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_lowmoi/")
+output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
+write_outputs_to_directory(
+  sceptre_object = sceptre_object,
+  directory = output_dir
+)
+message("sceptre outputs written to ", output_dir)
 
 ##########################
 # High-MOI CRISPRi example
@@ -130,8 +134,12 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results
-write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_highmoi/")
-}
+output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
+write_outputs_to_directory(
+  sceptre_object = sceptre_object,
+  directory = output_dir
+)
+message("sceptre outputs written to ", output_dir)
 }
 \seealso{
 Useful links:

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -75,7 +75,7 @@ write_outputs_to_directory(
 )
 message(
   "sceptre outputs written to a temporary directory; ",
-  'open with browseURL("', output_dir, '")'
+  'open with `browseURL("', output_dir, '")`'
 )
 
 ##########################
@@ -145,7 +145,7 @@ write_outputs_to_directory(
 )
 message(
   "sceptre outputs written to a temporary directory; ",
-  'open with browseURL("', output_dir, '")'
+  'open by running `browseURL("', output_dir, '")` in the console.'
 )
 }
 \seealso{

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -67,13 +67,16 @@ sceptre_object <- run_discovery_analysis(sceptre_object)
 plot(sceptre_object)
 print(sceptre_object)
 
-# 8. write results
+# 8. write results to a directory. tempdir() is used so this example is
+# self-contained; for a real analysis choose a directory you can find again,
+# e.g. file.path("~", "sceptre_outputs").
 output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
 message("sceptre outputs written to ", output_dir)
+# to open this directory in your file browser: browseURL(output_dir)
 
 ##########################
 # High-MOI CRISPRi example
@@ -133,13 +136,16 @@ sceptre_object <- run_discovery_analysis(sceptre_object)
 plot(sceptre_object)
 print(sceptre_object)
 
-# 8. write results
+# 8. write results to a directory. tempdir() is used so this example is
+# self-contained; for a real analysis choose a directory you can find again,
+# e.g. file.path("~", "sceptre_outputs").
 output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
 message("sceptre outputs written to ", output_dir)
+# to open this directory in your file browser: browseURL(output_dir)
 }
 \seealso{
 Useful links:

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -68,15 +68,16 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results to a directory. tempdir() is used so this example is
-# self-contained; for a real analysis choose a directory you can find again,
-# e.g. file.path("~", "sceptre_outputs").
+# self-contained; for a real analysis choose a directory you can find again.
 output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
-message("sceptre outputs written to ", output_dir)
-# to open this directory in your file browser: browseURL(output_dir)
+message(
+  "sceptre outputs written to a temporary directory; ",
+  'open with browseURL("', output_dir, '")'
+)
 
 ##########################
 # High-MOI CRISPRi example
@@ -137,15 +138,16 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results to a directory. tempdir() is used so this example is
-# self-contained; for a real analysis choose a directory you can find again,
-# e.g. file.path("~", "sceptre_outputs").
+# self-contained; for a real analysis choose a directory you can find again.
 output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
-message("sceptre outputs written to ", output_dir)
-# to open this directory in your file browser: browseURL(output_dir)
+message(
+  "sceptre outputs written to a temporary directory; ",
+  'open with browseURL("', output_dir, '")'
+)
 }
 \seealso{
 Useful links:

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -9,7 +9,6 @@
 \code{sceptre} is an R package for single-cell CRISPR screen data analysis, emphasizing statistical rigor, massive scalability, and ease of use.
 }
 \examples{
-\donttest{
 ##########################
 # Low-MOI CRISPRko example
 ##########################
@@ -68,7 +67,12 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results
-write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_lowmoi/")
+output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
+write_outputs_to_directory(
+  sceptre_object = sceptre_object,
+  directory = output_dir
+)
+message("sceptre outputs written to ", output_dir)
 
 ##########################
 # High-MOI CRISPRi example
@@ -129,8 +133,12 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results
-write_outputs_to_directory(sceptre_object = sceptre_object, "~/sceptre_outputs_highmoi/")
-}
+output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
+write_outputs_to_directory(
+  sceptre_object = sceptre_object,
+  directory = output_dir
+)
+message("sceptre outputs written to ", output_dir)
 }
 \seealso{
 Useful links:
@@ -148,6 +156,12 @@ Authors:
 \itemize{
   \item Louis Deutsch
   \item Eugene Katsevich \email{ekatsevi@wharton.upenn.edu}
+}
+
+Other contributors:
+\itemize{
+  \item Wharton Analytics [funder]
+  \item National Science Foundation (Grants DMS-2113072 and DMS-2310654) [funder]
 }
 
 }

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -67,15 +67,16 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results to a directory. tempdir() is used so this example is
-# self-contained; for a real analysis choose a directory you can find again,
-# e.g. file.path("~", "sceptre_outputs").
+# self-contained; for a real analysis choose a directory you can find again.
 output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
-message("sceptre outputs written to ", output_dir)
-# to open this directory in your file browser: browseURL(output_dir)
+message(
+  "sceptre outputs written to a temporary directory; ",
+  'open with browseURL("', output_dir, '")'
+)
 
 ##########################
 # High-MOI CRISPRi example
@@ -136,15 +137,16 @@ plot(sceptre_object)
 print(sceptre_object)
 
 # 8. write results to a directory. tempdir() is used so this example is
-# self-contained; for a real analysis choose a directory you can find again,
-# e.g. file.path("~", "sceptre_outputs").
+# self-contained; for a real analysis choose a directory you can find again.
 output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
-message("sceptre outputs written to ", output_dir)
-# to open this directory in your file browser: browseURL(output_dir)
+message(
+  "sceptre outputs written to a temporary directory; ",
+  'open with browseURL("', output_dir, '")'
+)
 }
 \seealso{
 Useful links:

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -76,7 +76,7 @@ write_outputs_to_directory(
 )
 message(
   "sceptre outputs written to a temporary directory; ",
-  'open with browseURL("', output_dir, '")'
+  'open with `browseURL("', output_dir, '")`'
 )
 
 ##########################
@@ -146,7 +146,7 @@ write_outputs_to_directory(
 )
 message(
   "sceptre outputs written to a temporary directory; ",
-  'open with browseURL("', output_dir, '")'
+  'open by running `browseURL("', output_dir, '")` in the console.'
 )
 }
 \seealso{

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -66,13 +66,16 @@ sceptre_object <- run_discovery_analysis(sceptre_object)
 plot(sceptre_object)
 print(sceptre_object)
 
-# 8. write results
+# 8. write results to a directory. tempdir() is used so this example is
+# self-contained; for a real analysis choose a directory you can find again,
+# e.g. file.path("~", "sceptre_outputs").
 output_dir <- file.path(tempdir(), "sceptre_outputs_lowmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
 message("sceptre outputs written to ", output_dir)
+# to open this directory in your file browser: browseURL(output_dir)
 
 ##########################
 # High-MOI CRISPRi example
@@ -132,13 +135,16 @@ sceptre_object <- run_discovery_analysis(sceptre_object)
 plot(sceptre_object)
 print(sceptre_object)
 
-# 8. write results
+# 8. write results to a directory. tempdir() is used so this example is
+# self-contained; for a real analysis choose a directory you can find again,
+# e.g. file.path("~", "sceptre_outputs").
 output_dir <- file.path(tempdir(), "sceptre_outputs_highmoi")
 write_outputs_to_directory(
   sceptre_object = sceptre_object,
   directory = output_dir
 )
 message("sceptre outputs written to ", output_dir)
+# to open this directory in your file browser: browseURL(output_dir)
 }
 \seealso{
 Useful links:

--- a/man/write_outputs_to_directory.Rd
+++ b/man/write_outputs_to_directory.Rd
@@ -12,7 +12,7 @@ write_outputs_to_directory(sceptre_object, directory)
 \item{directory}{a string giving the file path to a directory on disk in which to write the results}
 }
 \value{
-\code{NULL}, invisibly
+No return value; called for its side effect of writing files to \code{directory}.
 }
 \description{
 \code{write_outputs_to_directory()} writes the outputs of a \code{sceptre} analysis to a directory on disk. \code{write_outputs_to_directory()} writes several files to the specified directory: a text-based summary of the analysis (\code{analysis_summary.txt}), the various plots (\verb{*.png}), the calibration check, power check, discovery analysis results (\code{results_run_calibration_check.rds}, \code{results_run_power_check.rds}, and \code{results_run_discovery_analysis.rds}, respectively), and the binary gRNA-to-cell assignment matrix (\code{grna_assignment_matrix.rds}). See \href{https://timothy-barry.github.io/sceptre-book/sceptre.html#sec-sceptre_write_outputs_to_directory}{Section 8 of the introductory chapter in the manual} for more information about this function.

--- a/man/write_outputs_to_directory.Rd
+++ b/man/write_outputs_to_directory.Rd
@@ -13,7 +13,7 @@ write_outputs_to_directory(sceptre_object, directory)
 which to write the results}
 }
 \value{
-the value NULL
+\code{NULL}, invisibly
 }
 \description{
 \code{write_outputs_to_directory()} writes the outputs of a \code{sceptre} analysis to

--- a/man/write_outputs_to_directory.Rd
+++ b/man/write_outputs_to_directory.Rd
@@ -12,7 +12,7 @@ write_outputs_to_directory(sceptre_object, directory)
 \item{directory}{a string giving the file path to a directory on disk in which to write the results}
 }
 \value{
-the value NULL
+\code{NULL}, invisibly
 }
 \description{
 \code{write_outputs_to_directory()} writes the outputs of a \code{sceptre} analysis to a directory on disk. \code{write_outputs_to_directory()} writes several files to the specified directory: a text-based summary of the analysis (\code{analysis_summary.txt}), the various plots (\verb{*.png}), the calibration check, power check, discovery analysis results (\code{results_run_calibration_check.rds}, \code{results_run_power_check.rds}, and \code{results_run_discovery_analysis.rds}, respectively), and the binary gRNA-to-cell assignment matrix (\code{grna_assignment_matrix.rds}). See \href{https://timothy-barry.github.io/sceptre-book/sceptre.html#sec-sceptre_write_outputs_to_directory}{Section 8 of the introductory chapter in the manual} for more information about this function.

--- a/man/write_outputs_to_directory.Rd
+++ b/man/write_outputs_to_directory.Rd
@@ -13,7 +13,7 @@ write_outputs_to_directory(sceptre_object, directory)
 which to write the results}
 }
 \value{
-\code{NULL}, invisibly
+No return value; called for its side effect of writing files to \code{directory}.
 }
 \description{
 \code{write_outputs_to_directory()} writes the outputs of a \code{sceptre} analysis to


### PR DESCRIPTION
## What

The package-level example in `R/sceptre.R` (the full low-MOI + high-MOI SCEPTRE workflow) was wrapped in `\donttest{}` and wrote its outputs to the user's **home directory** (`~/sceptre_outputs_lowmoi/`, `~/sceptre_outputs_highmoi/`). This PR makes the example runnable and policy-compliant, and tidies the `write_outputs_to_directory()` experience along the way:

- **Removed `\donttest{}`** so the example runs during `R CMD check` / `BiocCheck`, giving the documented workflow real test coverage. On the bundled example datasets it completes in **~8s** end-to-end.
- **Redirected the two `write_outputs_to_directory()` calls** from `~/sceptre_outputs_*` to `file.path(tempdir(), "sceptre_outputs_*")`. This also matches the convention already used in `write_outputs_to_directory()`'s own example.
- **Reworked the post-write feedback.** A `message()` now reports that outputs went to a temporary directory and shows a directly runnable `browseURL("<path>")` to open it in the file browser — the path is named once. An adjacent comment explains that `tempdir()` is only used to keep the example self-contained, and that a real analysis should pass a directory it can find again.
- **Fixed `write_outputs_to_directory()` printing a stray `NULL`.** It is called for its side effect (writing files) but ended with `return(NULL)`, so a top-level call auto-printed `NULL` to the console — visible right in the example. It now returns `invisible(NULL)` (contract unchanged; no caller uses the value), and its `@return` doc uses the conventional "No return value, called for side effects" wording.

`man/sceptre-package.Rd` and `man/write_outputs_to_directory.Rd` regenerated via roxygen2.

## Why: Bioconductor prohibits writing to the home directory

From the [Bioconductor contributions guide, §14 "Other data"](https://contributions.bioconductor.org/data.html):

> It is not allowed to download or write any files to a users home directory, working directory, or installed package directory. Files should be cached as stated above with `BiocFileCache` (preferred) or `R_user_dir` or `tempdir()/tempfile()` if files should not be persistent.

The same rule appears in the [CRAN Repository Policy](https://cran.r-project.org/web/packages/policies.html):

> Packages should not write in the user's home filespace (including clipboards), nor anywhere else on the file system apart from the R session's temporary directory (or during installation in the location pointed to by `TMPDIR`: and such usage should be cleaned up). Limited exceptions may be allowed in interactive sessions if the package obtains confirmation from the user.

Note this is a **reviewer-enforced policy, not a checked one**: `R CMD check --as-cran` runs the home-writing example and reports it as clean (verified locally — 0 errors / 0 warnings on this change's predecessor), so it would only surface during Bioconductor review.

## Verification

- Extracted the example exactly as `R CMD check` does (`tools::Rd2ex`) and ran it: both pipelines complete in ~8s, each prints `sceptre outputs written to a temporary directory; open with browseURL("…")`, **nothing written to `$HOME`**, and no stray `NULL`.
- The only NOTE from `R CMD check --as-cran` on this repo is an unrelated `air.toml` top-level file, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
