### PR TITLE
Improve gRNA assignment formula diagnostics

### DIFF
--- a/R/mixture_model_functs.R
+++ b/R/mixture_model_functs.R
@@ -27,18 +27,20 @@ assign_grnas_to_cells_mixture <- function(
             formula_object = grna_assignment_hyperparameters$formula_object
         ),
         error = function(cnd) {
-            stop(
+            underlying_error <- conditionMessage(cnd)
+            cnd$message <- paste0(
                 "The `formula_object` used for gRNA assignment could not be ",
-                "converted to a valid design matrix. Check that the formula ",
-                "does not contain perfectly collinear or redundant covariates ",
-                "and that each categorical covariate has at least two observed ",
-                "levels. Supply a corrected `formula_object` to ",
+                "converted to a valid design matrix. Check the formula and ",
+                "covariate data. Possible causes include missing variables or ",
+                "values, non-finite values, categorical covariates with fewer ",
+                "than two observed levels, and perfectly collinear or ",
+                "redundant covariates. Supply a corrected `formula_object` to ",
                 "`assign_grnas()`; the formula used in ",
                 "`set_analysis_parameters()` may be appropriate.",
                 "\nUnderlying error: ",
-                conditionMessage(cnd),
-                call. = FALSE
+                underlying_error
             )
+            stop(cnd)
         }
     )
 

--- a/R/mixture_model_functs.R
+++ b/R/mixture_model_functs.R
@@ -21,9 +21,25 @@ assign_grnas_to_cells_mixture <- function(
     )
 
     # 1. obtain the covariate matrix
-    covariate_matrix <- convert_covariate_df_to_design_matrix(
-        covariate_data_frame = cell_covariate_data_frame,
-        formula_object = grna_assignment_hyperparameters$formula_object
+    covariate_matrix <- tryCatch(
+        convert_covariate_df_to_design_matrix(
+            covariate_data_frame = cell_covariate_data_frame,
+            formula_object = grna_assignment_hyperparameters$formula_object
+        ),
+        error = function(cnd) {
+            stop(
+                "The `formula_object` used for gRNA assignment could not be ",
+                "converted to a valid design matrix. Check that the formula ",
+                "does not contain perfectly collinear or redundant covariates ",
+                "and that each categorical covariate has at least two observed ",
+                "levels. Supply a corrected `formula_object` to ",
+                "`assign_grnas()`; the formula used in ",
+                "`set_analysis_parameters()` may be appropriate.",
+                "\nUnderlying error: ",
+                conditionMessage(cnd),
+                call. = FALSE
+            )
+        }
     )
 
     # 2. make the grna expression matrix row-accessible

--- a/tests/testthat/test-assign_grnas.R
+++ b/tests/testthat/test-assign_grnas.R
@@ -508,14 +508,10 @@ test_that("assign_grnas method=mixture reports invalid assignment formulas", {
         set_analysis_parameters(formula_object = ~1)
 
     expect_error(
-        assign_grnas(
-            scep_redundant,
-            method = "mixture",
-            formula_object = ~ covariate_1 + covariate_2
-        ),
+        assign_grnas(scep_redundant, method = "mixture"),
         regexp = paste0(
             "formula_object.*gRNA assignment.*",
-            "perfectly collinear or redundant covariates.*",
+            "Possible causes include.*perfectly collinear or redundant.*",
             "formula used in `set_analysis_parameters\\(\\)` may be appropriate"
         )
     )
@@ -536,8 +532,28 @@ test_that("assign_grnas method=mixture reports invalid assignment formulas", {
         assign_grnas(scep_constant, method = "mixture"),
         regexp = paste0(
             "formula_object.*gRNA assignment.*",
-            "categorical covariate has at least two observed levels.*",
+            "Possible causes include.*",
+            "categorical covariates with fewer than two observed levels.*",
             "Underlying error: contrasts can be applied only to factors"
         )
     )
+
+    missing_covariate_error <- tryCatch(
+        assign_grnas(
+            scep_redundant,
+            method = "mixture",
+            formula_object = ~missing_covariate
+        ),
+        error = identity
+    )
+    expect_s3_class(missing_covariate_error, "error")
+    expect_match(
+        conditionMessage(missing_covariate_error),
+        paste0(
+            "formula_object.*gRNA assignment.*",
+            "Possible causes include missing variables or values.*",
+            "Underlying error: object 'missing_covariate' not found"
+        )
+    )
+    expect_false(is.null(conditionCall(missing_covariate_error)))
 })

--- a/tests/testthat/test-assign_grnas.R
+++ b/tests/testthat/test-assign_grnas.R
@@ -489,3 +489,55 @@ test_that("assign_grnas method=mixture moi=high", {
         cells_getting_nt_1
     )
 })
+
+test_that("assign_grnas method=mixture reports invalid assignment formulas", {
+    test_data_list <- make_mock_base_data_for_testing_assign_grnas()
+    num_cells <- ncol(test_data_list$response_matrix)
+
+    redundant_covariates <- data.frame(
+        covariate_1 = seq_len(num_cells),
+        covariate_2 = 2 * seq_len(num_cells)
+    )
+    scep_redundant <- import_data(
+        grna_matrix = test_data_list$grna_matrix_all_0,
+        response_matrix = test_data_list$response_matrix,
+        grna_target_data_frame = test_data_list$grna_target_data_frame,
+        extra_covariates = redundant_covariates,
+        moi = "high"
+    ) |>
+        set_analysis_parameters(formula_object = ~1)
+
+    expect_error(
+        assign_grnas(
+            scep_redundant,
+            method = "mixture",
+            formula_object = ~ covariate_1 + covariate_2
+        ),
+        regexp = paste0(
+            "formula_object.*gRNA assignment.*",
+            "perfectly collinear or redundant covariates.*",
+            "formula used in `set_analysis_parameters\\(\\)` may be appropriate"
+        )
+    )
+
+    constant_covariate <- data.frame(
+        batch = factor(rep("batch_1", num_cells))
+    )
+    scep_constant <- import_data(
+        grna_matrix = test_data_list$grna_matrix_all_0,
+        response_matrix = test_data_list$response_matrix,
+        grna_target_data_frame = test_data_list$grna_target_data_frame,
+        extra_covariates = constant_covariate,
+        moi = "high"
+    ) |>
+        set_analysis_parameters(formula_object = ~1)
+
+    expect_error(
+        assign_grnas(scep_constant, method = "mixture"),
+        regexp = paste0(
+            "formula_object.*gRNA assignment.*",
+            "categorical covariate has at least two observed levels.*",
+            "Underlying error: contrasts can be applied only to factors"
+        )
+    )
+})


### PR DESCRIPTION
## Summary

- add gRNA-assignment context when mixture-model design-matrix construction fails
- list possible causes, including missing or non-finite covariates, single-level categorical covariates, and perfect collinearity
- direct users to pass a corrected `formula_object` to `assign_grnas()`, while preserving the underlying condition and error
- cover rank-deficient, single-level categorical, and unrelated missing-variable errors with regression tests

## Motivation

Mixture-based gRNA assignment constructs its own covariate design matrix. When that formula is invalid, users currently receive a low-level design-matrix error without being told that the failure occurred during gRNA assignment or how to correct the assignment formula.

This change improves the diagnostic only. It does not alter the formula, fall back to another model, or change the public API. It addresses the gRNA-assignment portion of #146; association-analysis diagnostics remain outside this PR.

Related to #146.

## Validation

- `devtools::test(filter = "assign_grnas")`: 31 passed
- full `devtools::test()`: 2,549 passed
- built-tarball `R CMD check --no-manual --as-cran`: 0 errors, 0 warnings, 4 pre-existing notes
