### PR TITLE
Update Bioconductor maintainer metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Authors@R:
            person(given = "Eugene",
            family = "Katsevich",
            role = c("aut", "cre"),
-           email = "ekatsevi@wharton.upenn.edu"),
+           email = "ekatsevi@wharton.upenn.edu",
+           comment = c(ORCID = "0000-0003-0598-2050")),
            person(given = "Wharton Analytics",
            role = "fnd"),
            person(given = "National Science Foundation",
@@ -53,6 +54,8 @@ Suggests:
     MASS
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-URL: https://timothy-barry.github.io/sceptre-book/, https://github.com/Katsevich-Lab/sceptre
+URL: https://katsevich-lab.github.io/sceptre/,
+    https://timothy-barry.github.io/sceptre-book/,
+    https://github.com/Katsevich-Lab/sceptre
 BugReports: https://github.com/Katsevich-Lab/sceptre/issues
 LazyData: false

--- a/man/sceptre-package.Rd
+++ b/man/sceptre-package.Rd
@@ -152,6 +152,7 @@ message(
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://katsevich-lab.github.io/sceptre/}
   \item \url{https://timothy-barry.github.io/sceptre-book/}
   \item \url{https://github.com/Katsevich-Lab/sceptre}
   \item Report bugs at \url{https://github.com/Katsevich-Lab/sceptre/issues}
@@ -159,12 +160,12 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Timothy Barry \email{tbarry@hsph.harvard.edu} (\href{https://orcid.org/0000-0002-4356-627X}{ORCID})
+\strong{Maintainer}: Eugene Katsevich \email{ekatsevi@wharton.upenn.edu} (\href{https://orcid.org/0000-0003-0598-2050}{ORCID})
 
 Authors:
 \itemize{
+  \item Timothy Barry \email{tbarry@hsph.harvard.edu} (\href{https://orcid.org/0000-0002-4356-627X}{ORCID})
   \item Louis Deutsch
-  \item Eugene Katsevich \email{ekatsevi@wharton.upenn.edu}
 }
 
 Other contributors:


### PR DESCRIPTION
## Summary

- add Eugene Katsevich's ORCID to `Authors@R`
- add the canonical pkgdown site to the package URLs
- regenerate package-level roxygen documentation so the installed help reflects the current maintainer

This is the first PR in a three-PR documentation stack. PR #228 contains the mixture-method disclosure and is based on this branch.

## Validation

- regenerated documentation with `devtools::document()`
- `git diff --check` passes
- the previously combined change passed R CMD check on macOS, Ubuntu release/oldrel, and Windows; this split PR will run the same CI independently